### PR TITLE
Fixes for TF and remappings

### DIFF
--- a/viso2_ros/launch/demo.launch
+++ b/viso2_ros/launch/demo.launch
@@ -13,14 +13,11 @@
 	<!-- Run the ROS package stereo_image_proc -->
 	<group ns="$(arg camera)" >
 		<node pkg="stereo_image_proc" type="stereo_image_proc" name="stereo_image_proc">
-	    	<rosparam file="$(arg disparity_params)"/>
+			<rosparam file="$(arg disparity_params)"/>
 		</node>
 	</group>
 
 	<!-- Run the viso2_ros package -->
-	<node pkg="viso2_ros" type="stereo_odometer" name="stereo_odometer" output="screen">
-		<remap from="stereo" to="$(arg camera)"/>
-		<remap from="image" to="image_rect"/>
-	</node>
-	
+	<node pkg="viso2_ros" type="stereo_odometer" name="stereo_odometer" output="screen" ns="$(arg camera)" />
+
 </launch>

--- a/viso2_ros/src/stereo_odometer.cpp
+++ b/viso2_ros/src/stereo_odometer.cpp
@@ -323,15 +323,6 @@ protected:
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "stereo_odometer");
-  if (ros::names::remap("stereo") == "stereo") {
-    ROS_WARN("'stereo' has not been remapped! Example command-line usage:\n"
-             "\t$ rosrun viso2_ros stereo_odometer stereo:=narrow_stereo image:=image_rect");
-  }
-  if (ros::names::remap("image").find("rect") == std::string::npos) {
-    ROS_WARN("stereo_odometer needs rectified input images. The used image "
-             "topic is '%s'. Are you sure the images are rectified?",
-             ros::names::remap("image").c_str());
-  }
 
   std::string transport = argc > 1 ? argv[1] : "raw";
   viso2_ros::StereoOdometer odometer(transport);

--- a/viso2_ros/src/stereo_processor.h
+++ b/viso2_ros/src/stereo_processor.h
@@ -103,20 +103,13 @@ protected:
     // Read local parameters
     ros::NodeHandle local_nh("~");
 
-    // Resolve topic names
-    ros::NodeHandle nh;
-    std::string stereo_ns = nh.resolveName("stereo");
-    std::string left_topic = ros::names::clean(stereo_ns + "/left/" + nh.resolveName("image"));
-    std::string right_topic = ros::names::clean(stereo_ns + "/right/" + nh.resolveName("image"));
-
-    std::string left_info_topic = stereo_ns + "/left/camera_info";
-    std::string right_info_topic = stereo_ns + "/right/camera_info";
-
     // Subscribe to four input topics.
-    ROS_INFO("Subscribing to:\n\t* %s\n\t* %s\n\t* %s\n\t* %s", 
-        left_topic.c_str(), right_topic.c_str(),
-        left_info_topic.c_str(), right_info_topic.c_str());
+    std::string left_topic = "left/image_rect";
+    std::string right_topic = "right/image_rect";
+    std::string left_info_topic = "left/camera_info";
+    std::string right_info_topic = "right/camera_info";
 
+    ros::NodeHandle nh;
     image_transport::ImageTransport it(nh);
     left_sub_.subscribe(it, left_topic, 1, transport);
     right_sub_.subscribe(it, right_topic, 1, transport);
@@ -148,6 +141,8 @@ protected:
       exact_sync_->registerCallback(boost::bind(&StereoProcessor::dataCb, this, _1, _2, _3, _4));
     }
   }
+
+  virtual ~StereoProcessor() { }
 
   /**
    * Implement this method in sub-classes 


### PR DESCRIPTION
#8: TF caching is implemented [as proposed](https://github.com/srv/viso2/issues/8#issuecomment-15403249) by Stephan.
#9: The possibilities to remap a stereo namespace or image topics are gone because this functionality didn't work as expected. Instead, the rather standard concept of [pushing down](http://www.ros.org/wiki/Nodes#Remapping_Arguments.A.22Pushing_Down.22) is recommended. Also please note that the new topic API is compatible with [another VO engines](http://www.ros.org/wiki/vslam_system/Tutorials/RunningVslamOnStereoData#Necessary_Data).
