### PR TITLE
Make sure msg files are processed first

### DIFF
--- a/viso2_ros/CMakeLists.txt
+++ b/viso2_ros/CMakeLists.txt
@@ -34,9 +34,11 @@ include_directories(src ${libviso2_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 add_executable(stereo_odometer
   src/stereo_odometer.cpp)
+add_dependencies(stereo_odometer ${catkin_EXPORTED_TARGETS})
 
 add_executable(mono_odometer
   src/mono_odometer.cpp)
+add_dependencies(mono_odometer ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(stereo_odometer ${OpenCV_LIBRARIES} ${catkin_LIBRARIES})
 find_package(Boost REQUIRED COMPONENTS signals thread)


### PR DESCRIPTION
Specifying message dependency of targets as per [catkin documentation](http://docs.ros.org/hydro/api/catkin/html/howto/cpp_msg_dependencies.html)

add_dependency: makes sure message headers are generated first 
