### PR TITLE
update PCL to libpcl-all-dev

### DIFF
--- a/viso2_ros/package.xml
+++ b/viso2_ros/package.xml
@@ -22,7 +22,7 @@
   <build_depend>cv_bridge</build_depend> 
   <build_depend>image_geometry</build_depend> 
   <build_depend>tf</build_depend> 
-  <build_depend>PCL</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
   <build_depend>pcl_ros</build_depend> 
   <build_depend>std_srvs</build_depend> 
   <build_depend>message_generation</build_depend> 
@@ -36,7 +36,7 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_geometry</run_depend> 
   <run_depend>tf</run_depend>
-  <run_depend>PCL</run_depend>
+  <run_depend>libpcl-all-dev</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
I think that this is a good fix. At least, `rosdep` doesn't know anything about `PCL`, but it's happy to resolve `libpcl-all-dev`.