### PR TITLE
viso2_ros: Fix include directory of libviso2 headers

### DIFF
--- a/viso2_ros/src/mono_odometer.cpp
+++ b/viso2_ros/src/mono_odometer.cpp
@@ -5,7 +5,7 @@
 #include <image_transport/image_transport.h>
 #include <image_geometry/pinhole_camera_model.h>
 
-#include <viso_mono.h>
+#include <libviso2/viso_mono.h>
 
 #include <viso2_ros/VisoInfo.h>
 

--- a/viso2_ros/src/odometry_params.h
+++ b/viso2_ros/src/odometry_params.h
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 
-#include <viso_stereo.h>
-#include <viso_mono.h>
+#include <libviso2/viso_stereo.h>
+#include <libviso2/viso_mono.h>
 
 namespace viso2_ros
 {

--- a/viso2_ros/src/stereo_odometer.cpp
+++ b/viso2_ros/src/stereo_odometer.cpp
@@ -5,7 +5,7 @@
 #include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
 
-#include <viso_stereo.h>
+#include <libviso2/viso_stereo.h>
 
 #include <viso2_ros/VisoInfo.h>
 


### PR DESCRIPTION
Since the default include directory for header files is `$CMAKE_INSTALL_PREFIX/include`, installed libviso2 headers specified without the prefix `libviso2/` are not found.
Please merge after #60 because without the changes there, `libviso2/src/` must be added.